### PR TITLE
RetroEval 2026 News & Misc Updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 	  <div class="col-lg-2"> 
 			  
 				<div class="alert alert-success" role="alert">
-				  <h4 class="alert-heading">News!</h4>	  
+				  <h4 class="alert-heading">News</h4>	  
 				</div>
 			  
 				<p>
@@ -96,7 +96,7 @@
 	
 	<div class="row">
 		<div class="footer">
-			<hm> Copyright 2022 | All Rights Reserved SIGGEN | <button onclick="topFunction()" id="myBtn" title="Go to top">Back To Top</button></hm>
+			<hm> Copyright 2026 | All Rights Reserved SIGGEN | <button onclick="topFunction()" id="myBtn" title="Go to top">Back To Top</button></hm>
 		</div>
 	</div>
 </div>

--- a/pages/events.html
+++ b/pages/events.html
@@ -49,7 +49,7 @@
 	  <div class="col-lg-2"> 
 			  
 				<div class="alert alert-success" role="alert">
-				  <h4 class="alert-heading">News!</h4>	  
+				  <h4 class="alert-heading">News</h4>	  
 				</div>
 			  
 				<p>
@@ -69,6 +69,9 @@
 <div class="alert alert-warning" role="alert"> <h3 align="left"><b>RECENT EVENTS</b></h3></div>
 
 			   <h5>
+<!-- 2025 -->
+<p><a rel="nofollow" class="external text" href="https://2025.inlgmeeting.org/">INLG 2025</a> was held in Hanoi Vietnam, 29 October-2 November. Conference proceedings are published in the <a rel="nofollow" class="external text" href="https://aclanthology.org/volumes/2025.inlg-main/">ACL Anthology</a>.</p>			   
+<!-- end of 2025 -->
 <!-- 2024 -->
 <p><a rel="nofollow" class="external text" href="https://2024.inlgmeeting.org/">INLG 2024</a> was held in Tokyo Japan, 23-27 September. Conference proceedings are published in the <a rel="nofollow" class="external text" href="https://aclanthology.org/volumes/2024.inlg-main/">ACL Anthology</a>.</p>			   
 <!-- end of 2024 -->

--- a/pages/information.html
+++ b/pages/information.html
@@ -49,7 +49,7 @@
 	  <div class="col-lg-2"> 
 			  
 				<div class="alert alert-success" role="alert">
-				  <h4 class="alert-heading">News!</h4>	  
+				  <h4 class="alert-heading">News</h4>	  
 				</div>
 			  
 				<p>
@@ -95,7 +95,7 @@ Please join the mailing list first (see above). Then you may use the email alias
 	<dl><dd>elected in December 2022 for the period from 1st January 2023 to 31st December 2026</dd></dl>
 
 <!--	Saad Mahamood	  -->
-	<ul><li><a rel="nofollow" class="external text" href="https://saad.me.uk/">Saad Mahamood</a> (<a rel="nofollow" class="external text" href="mailto:saad@saad.me.uk">mail</a>) <a rel="nofollow" class="external text" href="https://company.trivago.com/">Shopware</a>, Germany (secretary)</li></ul>
+	<ul><li><a rel="nofollow" class="external text" href="https://saad.me.uk/">Saad Mahamood</a> (<a rel="nofollow" class="external text" href="mailto:saad@saad.me.uk">mail</a>) <a rel="nofollow" class="external text" href="https://shopware.com/">Shopware</a>, Germany (secretary)</li></ul>
 	<dl><dd>elected in December 2024 for the period from 1st January 2025 to 31st December 2028</dd></dl>				  
 
 <!--	Simon Mille	  -->

--- a/pages/webinar.html
+++ b/pages/webinar.html
@@ -49,7 +49,7 @@
 	  <div class="col-lg-2"> 
 			  
 				<div class="alert alert-success" role="alert">
-				  <h4 class="alert-heading">News!</h4>	  
+				  <h4 class="alert-heading">News</h4>	  
 				</div>
 			  
 				<p>

--- a/text/news.html
+++ b/text/news.html
@@ -6,6 +6,7 @@
 	
 
 <ul>
+	<li>The sympoisum on Natural Language Generation Evaluations (<a href="https://retroeval.github.io">RetroEval 2026</a>) will be hosted in Aberdeen, United Kingdom from 1st to the 2nd of June 2026.</li> 
 	<li>This fall <a href="https://2026.inlgmeeting.org" target="_top">INLG 2026</a> will be in Utrecht, the Netherlands, the 17th through the 21st of October, 2026, just before <a href="https://2026.emnlp.org/">EMNLP 2026 in Hungary</a>.</li>
 	<li>
 	<a href="https://2025.inlgmeeting.org" target="_top">INLG 2025</a> was be held in Hanoi, Vietnam from Oct 29 to Nov 2, 2025!


### PR DESCRIPTION
+ Added news item for RetroEval 2026 
+ Cleaned up Misc elements on the website such as punctuation and fixing an incorrect link.
+ Added INLG 2025 as a recent event. 
